### PR TITLE
Fix template error handling; add logging support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,4 @@
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: ''  # pick a git hash / tag to point to
+    hooks:
+    -   id: flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+---
+language: python
+install:
+  - pip install flake8 wheel
+  - pip install -r requirements.txt
+python:
+  - "3.6"
+  - "3.7"
+  - "3.8"
+script:
+  - flake8 .
+  - pytest
+  - python3 setup.py sdist bdist_wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: python
 install:
-  - pip install flake8 wheel
+  - pip install flake8==3.8.3 wheel
   - pip install -r requirements.txt
 python:
   - "3.6"

--- a/pyesbulk/__init__.py
+++ b/pyesbulk/__init__.py
@@ -4,18 +4,31 @@ such opinions for creating templates (put_template()) and bulk indexing
 (streaming_bulk).
 """
 
-import sys, os, time, json, errno, logging, math
+import json
+import logging
+import math
+import time
 
-from random import SystemRandom
 from collections import Counter, deque
-from urllib3 import exceptions as ul_excs
+from datetime import datetime, tzinfo, timedelta
+from random import SystemRandom
+
 try:
-    from elasticsearch1 import VERSION as es_VERSION, helpers, exceptions as es_excs
+    from elasticsearch1 import (
+        VERSION as es_VERSION, helpers, exceptions as es_excs
+    )
     _es_logger = "elasticsearch1"
 except ImportError:
-    from elasticsearch import VERSION as es_VERSION, helpers, exceptions as es_excs
+    from elasticsearch import (
+        VERSION as es_VERSION, helpers, exceptions as es_excs
+    )
     _es_logger = "elasticsearch"
+assert es_VERSION[0] == 1, (
+    "INTERNAL ERROR: only Elasticsearch V1 client is currently supported."
+)
 
+# Version of py-es-bulk
+__VERSION__ = "1.0.0"
 
 # Use the random number generator provided by the host OS to calculate our
 # random backoff.
@@ -31,10 +44,26 @@ _op_type = "create"
 # want to timeout waiting for Elasticsearch and then have to retry, as that
 # can add undue burden to the Elasticsearch cluster.
 _request_timeout = 100000*60.0
+# Maximum length of messages logged by streaming_bulk()
+_MAX_ERRMSG_LENGTH = 16384
+
+
+class simple_utc(tzinfo):
+    def tzname(self, *args, **kwargs):
+        return "UTC"
+
+    def utcoffset(self, dt):
+        return timedelta(0)
+
+    def dst(self, dt):
+        return timedelta(0)
 
 
 def _tstos(ts=None):
-    return time.strftime("%Y-%m-%dT%H:%M:%S-%Z", time.gmtime(ts))
+    if ts is None:
+        ts = time.time()
+    dt = datetime.utcfromtimestamp(ts).replace(tzinfo=simple_utc())
+    return dt.strftime("%Y-%m-%dT%H:%M:%S-%Z")
 
 
 def _calc_backoff_sleep(backoff):
@@ -43,65 +72,128 @@ def _calc_backoff_sleep(backoff):
     return _r.uniform(0, min(b, _MAX_SLEEP_TIME))
 
 
+def _sleep_w_backoff(backoff):
+    time.sleep(_calc_backoff_sleep(backoff))
+
+
 def quiet_loggers():
     """
     A convenience function to quiet the urllib3 and elasticsearch1 loggers.
     """
     logging.getLogger("urllib3").setLevel(logging.FATAL)
-    logging.getLogger(es_logger).setLevel(logging.FATAL)
+    logging.getLogger(_es_logger).setLevel(logging.FATAL)
 
 
-def put_template(es, name, body):
+# The 5xx codes on which template PUT operations are retried.
+_RETRY_5xxS = [500, 503, 504]
+
+
+def put_template(es, name=None, mapping_name=None, body=None):
     """
-    put_template(es, name, body)
+    put_template(es, name, mapping_name, body)
+
+    Updates a given template when the version of the template as
+    stored in the mapping is different from the existing one.
 
     Arguments:
 
         es - An Elasticsearch client object already constructed
         name - The name of the template to use
+        mapping_name - The name of the mapping used in the template
         body - The payload body of the template
 
     Returns:
 
         A tuple with the start and end times of the PUT operation, along
-        with the number of times the operation was retried.
+        with the number of times the operation was retried, and string
+        of keywords indicating note-worthy behavior (currently only
+        "original-no-version", which is returned when the mapping being
+        updated has no version number).
 
         Failure modes are raised as exceptions.
     """
+    assert name is not None and mapping_name is not None and body is not None
     retry = True
     retry_count = 0
+    original_no_version = False
     backoff = 1
     beg, end = time.time(), None
+    try:
+        body_ver = int(body["mappings"][mapping_name]["_meta"]["version"])
+    except KeyError:
+        raise Exception(
+            f"Bad template, {name}: mapping name, '{mapping_name}',"
+            " missing from template"
+        )
     while retry:
+        original_no_version = False  # Initialized twice for proper scope
+        try:
+            tmpl = es.indices.get_template(name=name)
+        except es_excs.ConnectionError:
+            # We retry all connection errors
+            _sleep_w_backoff(backoff)
+            backoff += 1
+            retry_count += 1
+            continue
+        except es_excs.TransportError as exc:
+            if exc.status_code == 404:
+                # We expected a "not found", we'll PUT below.
+                pass
+            elif exc.status_code < 500:
+                # All other non-5xx codes are some kind of error
+                raise
+            else:
+                # Only retry on certain 5xx errors
+                if exc.status_code not in _RETRY_5xxS:
+                    raise
+                _sleep_w_backoff(backoff)
+                backoff += 1
+                retry_count += 1
+                continue
+        else:
+            try:
+                tmpl_ver = int(
+                    tmpl[name]["mappings"][mapping_name]["_meta"]["version"]
+                )
+            except KeyError:
+                original_no_version = True
+            else:
+                if tmpl_ver == body_ver:
+                    break
         try:
             es.indices.put_template(name=name, body=body)
-        except es_excs.ConnectionError as exc:
+        except es_excs.ConnectionError:
             # We retry all connection errors
-            time.sleep(_calc_backoff_sleep(backoff))
+            _sleep_w_backoff(backoff)
             backoff += 1
             retry_count += 1
         except es_excs.TransportError as exc:
-            # Only retry on certain 500 errors
-            if exc.status_code not in [500, 503, 504]:
+            if exc.status_code < 500:
+                # Somehow the PUT payload was in error, don't retry.
                 raise
-            time.sleep(_calc_backoff_sleep(backoff))
+            elif exc.status_code not in _RETRY_5xxS:
+                # Only retry on certain 500 errors
+                raise
+            _sleep_w_backoff(backoff)
             backoff += 1
             retry_count += 1
         else:
             retry = False
     end = time.time()
-    return beg, end, retry_count
+    note = "original-no-version" if original_no_version else ""
+    return beg, end, retry_count, note
 
 
-def streaming_bulk(es, actions, errorsfp):
+def streaming_bulk(es, actions, errorsfp, logger):
     """
-    streaming_bulk(es, actions, errorsfp)
+    streaming_bulk(es, actions, errorsfp, logger)
 
     Arguments:
 
         es - An Elasticsearch client object already constructed
         actions - An iterable for the documents to be indexed
         errorsfp - A file pointer for where to write 400 errors
+        logger - A python logging object to use to report behaviors
 
     Returns:
 
@@ -122,30 +214,37 @@ def streaming_bulk(es, actions, errorsfp):
 
     def actions_tracking_closure(cl_actions):
         for cl_action in cl_actions:
-            assert '_id' in cl_action
-            assert '_index' in cl_action
-            assert '_type' in cl_action
-            assert _op_type == cl_action['_op_type']
+            for field in ("_id", "_index", "_type"):
+                assert (
+                    field in cl_action
+                ), f"Action missing '{field}' field: {cl_action!r}"
+            assert _op_type == cl_action["_op_type"], (
+                "Unexpected _op_type"
+                f" value \"{cl_action['_op_type']}\" in action {cl_action!r}"
+            )
 
-            actions_deque.append((0, cl_action))   # Append to the right side ...
+            # Append to the right side ...
+            actions_deque.append((0, cl_action))
             yield cl_action
-            # if after yielding an action some actions appear on the retry deque
-            # start yielding those actions until we drain the retry queue.
+            # If after yielding an action some actions appear on the retry
+            # deque, start yielding those actions until we drain the retry
+            # queue.
             backoff = 1
             while len(actions_retry_deque) > 0:
-                time.sleep(calc_backoff_sleep(backoff))
-                retries_tracker['retries'] += 1
+                _sleep_w_backoff(backoff)
+                retries_tracker["retries"] += 1
                 retry_actions = []
                 # First drain the retry deque entirely so that we know when we
                 # have cycled through the entire list to be retried.
                 while len(actions_retry_deque) > 0:
                     retry_actions.append(actions_retry_deque.popleft())
                 for retry_count, retry_action in retry_actions:
-                    actions_deque.append((retry_count, retry_action))   # Append to the right side ...
+                    # Append to the right side ...
+                    actions_deque.append((retry_count, retry_action))
                     yield retry_action
-                # if after yielding all the actions to be retried, some show up
-                # on the retry deque again, we extend our sleep backoff to avoid
-                # pounding on the ES instance.
+                # If after yielding all the actions to be retried, some show
+                # up on the retry deque again, we extend our sleep backoff to
+                # avoid pounding on the ES instance.
                 backoff += 1
 
     beg, end = time.time(), None
@@ -157,21 +256,43 @@ def streaming_bulk(es, actions, errorsfp):
     generator = actions_tracking_closure(actions)
 
     streaming_bulk_generator = helpers.streaming_bulk(
-            es, generator, raise_on_error=False,
-            raise_on_exception=False, request_timeout=_request_timeout)
+        es,
+        generator,
+        raise_on_error=False,
+        raise_on_exception=False,
+        request_timeout=_request_timeout,
+    )
 
     for ok, resp_payload in streaming_bulk_generator:
         retry_count, action = actions_deque.popleft()
         try:
             resp = resp_payload[_op_type]
-            status = resp['status']
         except KeyError as e:
-            assert not ok
-            # resp is not of expected form
-            print(resp)
+            assert not ok, f"ok = {ok!r}, e = {e!r}"
+            assert (
+                e.args[0] == _op_type
+            ), f"e.args = {e.args!r}, _op_type = {_op_type!r}"
+            # For whatever reason, some errors are always returned using
+            # the "index" operation type instead of _op_type (e.g. "create"
+            # op type still comes back as an "index" response).
+            try:
+                resp = resp_payload["index"]
+            except KeyError:
+                # resp is not of expected form; set it to the complete
+                # payload, so that it can be reported properly below.
+                resp = resp_payload
+        try:
+            status = resp["status"]
+        except KeyError as e:
+            assert not ok, f"ok = {ok!r}, e = {e!r}"
+            # Limit the length of the error message.
+            logger.error("{!r}"[:_MAX_ERRMSG_LENGTH], e)
             status = 999
         else:
-            assert action['_id'] == resp['_id']
+            assert action["_id"] == resp["_id"], (
+                "Response encountered out of order from actions, "
+                f"action = {action!r}, response = {resp!r}"
+            )
         if ok:
             successes += 1
         else:
@@ -183,25 +304,79 @@ def streaming_bulk(es, actions, errorsfp):
                     # ... otherwise consider it successful.
                     successes += 1
             elif status == 400:
-                doc = {
+                try:
+                    exc_payload = resp["exception"]
+                except KeyError:
+                    pass
+                else:
+                    # We have an exception object in the response object
+                    # which is not always JSON serializable, so we use
+                    # `repr` to turn that exception into a serializable
+                    # string while maintaining as much information about
+                    # the exception as possible.
+                    resp["exception"] = repr(exc_payload)
+                jsonstr = json.dumps(
+                    {
                         "action": action,
                         "ok": ok,
                         "resp": resp,
                         "retry_count": retry_count,
-                        "timestamp": tstos(time.time())
-                        }
-                jsonstr = json.dumps(doc, indent=4, sort_keys=True)
+                        "timestamp": _tstos(),
+                    },
+                    indent=4,
+                    sort_keys=True,
+                )
                 print(jsonstr, file=errorsfp)
                 errorsfp.flush()
                 failures += 1
             else:
-                # Retry all other errors
-                print(resp)
-                actions_retry_deque.append((retry_count + 1, action))
+                try:
+                    exc_payload = resp["exception"]
+                except KeyError:
+                    pass
+                else:
+                    resp["exception"] = repr(exc_payload)
+                try:
+                    error = resp["error"]
+                except KeyError:
+                    error = ""
+                if status == 403 and error.startswith("IndexClosedException"):
+                    # Don't retry closed index exceptions
+                    jsonstr = json.dumps(
+                        {
+                            "action": action,
+                            "ok": ok,
+                            "resp": resp,
+                            "retry_count": retry_count,
+                            "timestamp": _tstos(),
+                        },
+                        indent=4,
+                        sort_keys=True,
+                    )
+                    print(jsonstr, file=errorsfp)
+                    errorsfp.flush()
+                    failures += 1
+                else:
+                    # Retry all other errors.
+                    # Limit the length of the warning message.
+                    logger.warning(
+                        "retrying action: {}",
+                        json.dumps(resp)[:_MAX_ERRMSG_LENGTH]
+                    )
+                    actions_retry_deque.append((retry_count + 1, action))
 
     end = time.time()
 
-    assert len(actions_deque) == 0
-    assert len(actions_retry_deque) == 0
+    if len(actions_deque) > 0:
+        logger.error(
+            "We still have {:d} actions in the deque", len(actions_deque)
+        )
+    if len(actions_retry_deque) > 0:
+        logger.error(
+            "We still have {:d} retry actions in the deque",
+            len(actions_retry_deque)
+        )
 
-    return (beg, end, successes, duplicates, failures, retries_tracker['retries'])
+    return (
+        beg, end, successes, duplicates, failures, retries_tracker['retries']
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+elasticsearch1

--- a/tests/functests.py
+++ b/tests/functests.py
@@ -9,11 +9,13 @@ if __name__ == '__main__':
     _op_type = "create"
 
     def _make_source_id(source):
-        return hashlib.md5(json.dumps(source, sort_keys=True).encode('utf-8')).hexdigest()
+        return hashlib.md5(
+            json.dumps(source, sort_keys=True).encode('utf-8')
+        ).hexdigest()
 
     def fake_gen():
         for data in range(0, 10):
-            source = { 'data': data }
+            source = {'data': data}
             action = {
                 _op_type: {
                     "_index":   'test-pyesbulk-streaming_bulk',
@@ -23,7 +25,9 @@ if __name__ == '__main__':
                 }
             yield action, source
 
-    es_client = Elasticsearch([ {"host": sys.argv[1], "port": sys.argv[2] } ], max_retries=0)
-    with open("errors.json", "w") as errorfp):
+    es_client = Elasticsearch(
+        [{"host": sys.argv[1], "port": sys.argv[2]}], max_retries=0
+    )
+    with open("errors.json", "w") as errorfp:
         res = streaming_bulk(es_client, fake_gen(), errorfp)
     print(repr(res))

--- a/tests/put_template_test.py
+++ b/tests/put_template_test.py
@@ -9,16 +9,18 @@ class MockException(Exception):
     pass
 
 
-class MockElasticsearch(object):
+class MockElasticsearch():
     def __init__(self, mock):
         self.indices = mock
 
 
-class MockPutTemplate(object):
-    def __init__(self, behavior=None):
+class MockTemplateApis():
+    def __init__(self, behavior=None, mapping_name=None, version=42):
         self.name = None
         self.body = None
         self.behavior = behavior
+        self.mapping_name = mapping_name
+        self.version = 42
 
     def put_template(self, *args, **kwargs):
         assert 'name' in kwargs and 'body' in kwargs
@@ -38,80 +40,122 @@ class MockPutTemplate(object):
                 raise MockException()
             elif behavior == "ce":
                 raise es_excs.ConnectionError(None, "fake ce", Exception())
-            elif behavior in ( "500", "501", "502", "503", "504" ):
-                raise es_excs.TransportError(int(behavior), "fake 50x", Exception())
+            elif behavior in ("500", "501", "502", "503", "504"):
+                raise es_excs.TransportError(
+                    int(behavior), "fake 50x", Exception()
+                )
         return None
 
+    def get_template(self, *args, **kwargs):
+        assert 'name' in kwargs
+        name = kwargs['name']
+        tmpl = dict()
+        if self.mapping_name is not None:
+            tmpl[name] = dict(mappings=dict())
+            tmpl[name]['mappings'][self.mapping_name] = dict(
+                _meta=dict(version=self.version)
+            )
+        else:
+            # Empty dict indicates template not found
+            pass
+        return tmpl
 
-class MyTime(object):
+
+class MyTime():
     """Monotonically incrementing time based on the # of times the tick()
     method is called."""
+
     def __init__(self):
         self._tick = 0
+
     def tick(self):
         _tick = self._tick
         self._tick += 1
         return _tick
+
 
 # FIXME: mock _calc_sleep_backoff and track backoff numbers
 
 @pytest.fixture(autouse=True)
 def patch_time(monkeypatch):
     clock = MyTime()
+
     def mytime():
         return clock.tick()
+
     monkeypatch.setattr(time, 'time', mytime)
+
 
 @pytest.fixture(autouse=True)
 def patch_sleep(monkeypatch):
+
     def mysleep(*args, **kwargs):
-        return;
+        return
+
     monkeypatch.setattr(time, 'sleep', mysleep)
+
 
 def test_put_template():
     # Assert that a one-n-done call works as expected
-    mpt = MockPutTemplate()
+    mpt = MockTemplateApis()
     es = MockElasticsearch(mpt)
-    body = dict(one=1, two=2)
-    res = put_template(es, "mytemplate", body)
-    beg, end, retry_count = res
+    mappings = {'prefix-mapname0': {'_meta': {'version': 0}}}
+    body = dict(one=1, two=2, mappings=mappings)
+    res = put_template(
+        es, name="mytemplate", mapping_name="prefix-mapname0", body=body
+    )
+    beg, end, retry_count, note = res
     assert beg == 0
     assert end == 1
     assert retry_count == 0
+    assert note == "original-no-version"
     assert mpt.name == "mytemplate"
     assert mpt.body == body
 
+
 def test_put_template_not_retried():
     # Assert that a 500 error is raised as a TransportError exception
-    mpt = MockPutTemplate(behavior=["501"])
+    mpt = MockTemplateApis(behavior=["501"])
     es = MockElasticsearch(mpt)
-    body = dict(one=1, two=2)
-    with pytest.raises(es_excs.TransportError) as excinfo:
-        res = put_template(es, "mytemplate", body)
+    mappings = {'prefix-mapname0': {'_meta': {'version': 0}}}
+    body = dict(one=1, two=2, mappings=mappings)
+    with pytest.raises(es_excs.TransportError):
+        put_template(
+            es, name="mytemplate", mapping_name="prefix-mapname0", body=body
+        )
     assert mpt.name == "mytemplate"
     assert mpt.body == body
+
 
 def test_put_template_retries():
     # Assert that ConnectionErrors and TransportErrors are properly retried
     # until successful.
-    mpt = MockPutTemplate(behavior=["ce", "ce", "ce", "500", "503", "504"])
+    mpt = MockTemplateApis(behavior=["ce", "ce", "ce", "500", "503", "504"])
     es = MockElasticsearch(mpt)
-    body = dict(one=1, two=2)
-    res = put_template(es, "mytemplate", body)
-    beg, end, retry_count = res
+    mappings = {'prefix-mapname0': {'_meta': {'version': 0}}}
+    body = dict(one=1, two=2, mappings=mappings)
+    res = put_template(
+        es, name="mytemplate", mapping_name="prefix-mapname0", body=body
+    )
+    beg, end, retry_count, note = res
     assert beg == 0
     assert end == 1
     assert retry_count == 6
+    assert note == "original-no-version"
     assert mpt.name == "mytemplate"
     assert mpt.body == body
+
 
 def test_put_template_exc():
     # Assert that if es.indices.put_template() raises an unknown exception
     # it is passed along to the caller.
-    mpt = MockPutTemplate(behavior=["exception"])
+    mpt = MockTemplateApis(behavior=["exception"])
     es = MockElasticsearch(mpt)
-    body = dict(one=1, two=2)
-    with pytest.raises(MockException) as excinfo:
-        res = put_template(es, "mytemplate", body)
+    mappings = {'prefix-mapname0': {'_meta': {'version': 0}}}
+    body = dict(one=1, two=2, mappings=mappings)
+    with pytest.raises(MockException):
+        put_template(
+            es, name="mytemplate", mapping_name="prefix-mapname0", body=body
+        )
     assert mpt.name == "mytemplate"
     assert mpt.body == body

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -3,19 +3,22 @@ import pytest
 
 from pyesbulk import _tstos, _calc_backoff_sleep, _r
 
-@pytest.fixture(name="mockgmtime")
-def patch_time(monkeypatch):
-    st = time.gmtime(873417700)
-    def mygmtime(cls):
-        return st
-    monkeypatch.setattr(time, 'gmtime', mygmtime)
 
-@pytest.mark.usefixtures("mockgmtime")
+@pytest.fixture(name="mocktime")
+def patch_time(monkeypatch):
+    def mytime():
+        return 873417700
+    monkeypatch.setattr(time, 'time', mytime)
+
+
+@pytest.mark.usefixtures("mocktime")
 def test_tstos():
     assert _tstos() == "1997-09-05T00:01:40-UTC"
 
+
 def test_tstos_w_param():
     assert _tstos(873417600) == "1997-09-05T00:00:00-UTC"
+
 
 @pytest.fixture(name="mockuniform")
 def patch_uniform(monkeypatch):
@@ -23,6 +26,7 @@ def patch_uniform(monkeypatch):
         assert zero == 0
         return m
     monkeypatch.setattr(_r, 'uniform', myuniform)
+
 
 @pytest.mark.usefixtures("mockuniform")
 def test_calc_backoff_sleep():


### PR DESCRIPTION
The exceptions were being caught in the wrong order such that `ConnectionError` exceptions, which are a sub-class of `TransportError`, were not being considered.

We also add support for only updating a template when the template's mapping version is different.

We add a `logger` argument for `streaming_bulk()` so that we have a bit more insight into what is happening while processing actions.

Further, we fix the failing unit tests, add Travis CI integration, and ensure the code passes flake8.