### PR TITLE
Initial support for Elasticsearch V7

### DIFF
--- a/pyesbulk/__init__.py
+++ b/pyesbulk/__init__.py
@@ -150,35 +150,30 @@ def _get_meta_version(name, body):
     if not isinstance(body, dict):
         raise TypeError
     underbody = body
-    if "_meta" not in body:
-        # Elasticsearch V1 allows multiple named templates, but since they're
-        # going into the same index we require that the versions be the same
-        # since we can return only one.
-        underbody = body[next(iter(body))]
-        version = None
-        for key in body:
-            try:
+    version = None
+    try:
+        if "_meta" not in body:
+            # Elasticsearch V1 allows multiple named templates in an index;
+            # we require that the versions be the same since we can return
+            # only one.
+            underbody = body[next(iter(body))]
+            for key in body:
                 v = int(body[key]["_meta"]["version"])
                 if not version:
                     version = v
                 else:
                     if v != version:
                         raise Exception(
-                            f"Bad template, multiple templates with "
+                            f"Bad template, {name}: multiple templates with "
                             "differing versions at {key}"
                         )
-            except KeyError:
-                raise Exception(
-                    f"Bad template, {key}: template has no '_meta' version"
-                )
-    try:
-        version = int(underbody["_meta"]["version"])
+        else:
+            version = int(underbody["_meta"]["version"])
     except KeyError:
         raise Exception(
-            f"Bad template, {name}: '_meta' version missing from template"
+            f"Bad template, {name}: '_meta version' missing from template"
         )
-    else:
-        return version
+    return version
 
 
 def put_template(

--- a/pyesbulk/__init__.py
+++ b/pyesbulk/__init__.py
@@ -247,7 +247,7 @@ def put_template(
                 raise
         except Exception as e:
             logger.error(
-                f"Unexpected exception checking %s: %r", name, e
+                "Unexpected exception checking %s: %r", name, e
             )
             raise
         else:
@@ -280,7 +280,7 @@ def put_template(
                 raise
         except Exception as e:
             logger.error(
-                f"Unexpected exception checking %s: %r", name, e
+                "Unexpected exception checking %s: %r", name, e
             )
             raise
         else:

--- a/pyesbulk/__init__.py
+++ b/pyesbulk/__init__.py
@@ -8,27 +8,64 @@ import json
 import logging
 import math
 import time
+import inspect
+import importlib
+from pathlib import Path
 
 from collections import Counter, deque
 from datetime import datetime, tzinfo, timedelta
 from random import SystemRandom
 
-try:
-    from elasticsearch1 import (
-        VERSION as es_VERSION, helpers, exceptions as es_excs
+
+def _import_elasticsearch(es):
+    """
+    _import_elasticsearch Import the necessary Elasticsearch attributes from
+    the Elasticsearch module used to create an Elasticsearch instance, and
+    binds the 'exceptions' sub-module globally as "es_excs" and the 'helpers'
+    sub-module globally as 'helpers'.
+
+    NOTE: simply importing 'elasticsearch' won't work if the caller is using
+    'elasticsearch1' (or vice versa), because the 'es_excs' exception classes
+    won't match our 'except' clauses, and template registration won't work!
+
+    Args:
+        es (Elasticsearch): An Elasticsearch object
+    """
+
+    # Get the file path of the Elasticsearch class
+    es_import = Path(inspect.getfile(type(es)))
+
+    # Walk up the file path to the directory that contains
+    # "elasticsearch" ... this should be either "elasticsearch1" for a V1
+    # or "elasticsearch" for a later version.
+    #
+    # In a unit test environment, we won't recognize the mock path, and
+    # for that and as a fallback, if we get to the root without finding
+    # a match, just import 'elasticsearch'.
+    path = es_import.parent
+    while "elasticsearch" not in path.name and path.name != "":
+        path = path.parent
+    module = path.name
+    if module == "":
+        module = "elasticsearch"
+
+    # Dymamically import the module so that we can identify, import, and
+    # bind the sub-modules we need.
+    es_module = importlib.import_module(module)
+
+    # I don't know why 'exceptions' is visible as an attribute of the module
+    # but 'helpers' isn't. Therefore, the import mechanism is different. We are
+    # manually binding global names matching the original static imports.
+    # g = globals()
+    global es_excs, helpers
+    es_excs = importlib.import_module(
+        getattr(es_module, "exceptions").__name__
     )
-    _es_logger = "elasticsearch1"
-except ImportError:
-    from elasticsearch import (
-        VERSION as es_VERSION, helpers, exceptions as es_excs
-    )
-    _es_logger = "elasticsearch"
-assert es_VERSION[0] == 1, (
-    "INTERNAL ERROR: only Elasticsearch V1 client is currently supported."
-)
+    helpers = importlib.import_module(es_module.__name__ + ".helpers")
+
 
 # Version of py-es-bulk
-__VERSION__ = "1.0.0"
+__VERSION__ = "2.0.0"
 
 # Use the random number generator provided by the host OS to calculate our
 # random backoff.
@@ -43,7 +80,7 @@ _op_type = "create"
 # 100,000 minute timeout talking to Elasticsearch; basically we just don't
 # want to timeout waiting for Elasticsearch and then have to retry, as that
 # can add undue burden to the Elasticsearch cluster.
-_request_timeout = 100000*60.0
+_request_timeout = 100000 * 60.0
 # Maximum length of messages logged by streaming_bulk()
 _MAX_ERRMSG_LENGTH = 16384
 
@@ -81,14 +118,72 @@ def quiet_loggers():
     A convenience function to quiet the urllib3 and elasticsearch1 loggers.
     """
     logging.getLogger("urllib3").setLevel(logging.FATAL)
-    logging.getLogger(_es_logger).setLevel(logging.FATAL)
+    logging.getLogger("elasticsearch").setLevel(logging.FATAL)
 
 
 # The 5xx codes on which template PUT operations are retried.
 _RETRY_5xxS = [500, 503, 504]
 
 
-def put_template(es, name=None, mapping_name=None, body=None):
+def _get_meta_version(name, body):
+    """
+    _get_meta_version Try to find an "_meta":{"version": "value"} in the
+    specified template body.
+
+    For V7 and beyond, a template should not have a name, which means the
+    mapping body includes an "_meta" key directly.
+
+    For V6 and V7 there may be an "_doc" key in the top level dict, which
+    will have "_meta" as a second level key.
+
+    Earlier versions will normally have a "document type" as the first
+    level key, with "_meta" underneath.
+
+    We're being accommodating here: if the first level dict includes an
+    "_meta" key, we'll use it. If not, and the first level dict has a single
+    key, we'll look for "_meta" under that.
+
+    Args:
+        body (dict): An Elasticsearch index document template "mappings"
+        document.
+    """
+    if not isinstance(body, dict):
+        raise TypeError
+    underbody = body
+    if "_meta" not in body:
+        # Elasticsearch V1 allows multiple named templates, but since they're
+        # going into the same index we require that the versions be the same
+        # since we can return only one.
+        underbody = body[next(iter(body))]
+        version = None
+        for key in body:
+            try:
+                v = int(body[key]["_meta"]["version"])
+                if not version:
+                    version = v
+                else:
+                    if v != version:
+                        raise Exception(
+                            f"Bad template, multiple templates with "
+                            "differing versions at {key}"
+                        )
+            except KeyError:
+                raise Exception(
+                    f"Bad template, {key}: template has no '_meta' version"
+                )
+    try:
+        version = int(underbody["_meta"]["version"])
+    except KeyError:
+        raise Exception(
+            f"Bad template, {name}: '_meta' version missing from template"
+        )
+    else:
+        return version
+
+
+def put_template(
+        es, name=None, mapping_name=None, body=None
+):
     """
     put_template(es, name, mapping_name, body)
 
@@ -113,22 +208,26 @@ def put_template(es, name=None, mapping_name=None, body=None):
         Failure modes are raised as exceptions.
     """
     assert name is not None and mapping_name is not None and body is not None
+    _import_elasticsearch(es)
+    logger = logging.getLogger()
     retry = True
     retry_count = 0
     original_no_version = False
     backoff = 1
     beg, end = time.time(), None
-    try:
-        body_ver = int(body["mappings"][mapping_name]["_meta"]["version"])
-    except KeyError:
-        raise Exception(
-            f"Bad template, {name}: mapping name, '{mapping_name}',"
-            " missing from template"
-        )
+    mapping = body["mappings"]
+    body_ver = _get_meta_version(name, mapping)
     while retry:
         original_no_version = False  # Initialized twice for proper scope
         try:
             tmpl = es.indices.get_template(name=name)
+        except es_excs.NotFoundError as exc:
+            if exc.status_code == 404:
+                # We expected a "not found", we'll PUT below.
+                pass
+            else:
+                # Not sure what to do here? Can it be anything except 404?
+                raise
         except es_excs.ConnectionError:
             # We retry all connection errors
             _sleep_w_backoff(backoff)
@@ -137,7 +236,9 @@ def put_template(es, name=None, mapping_name=None, body=None):
             continue
         except es_excs.TransportError as exc:
             if exc.status_code == 404:
-                # We expected a "not found", we'll PUT below.
+                # We expected a "not found", we'll PUT below. NOTE: this may
+                # trigger on Elasticsearch 1, but on Elasticsearch 7 a 404
+                # is instead packaged as a NotFoundError exception!
                 pass
             elif exc.status_code in _RETRY_5xxS:
                 # Only retry on certain 5xx errors
@@ -149,11 +250,14 @@ def put_template(es, name=None, mapping_name=None, body=None):
                 # All other error codes are some kind of error we don't attempt
                 # to retry.
                 raise
+        except Exception as e:
+            logger.error(
+                f"Unexpected exception checking %s: %r", name, e
+            )
+            raise
         else:
             try:
-                tmpl_ver = int(
-                    tmpl[name]["mappings"][mapping_name]["_meta"]["version"]
-                )
+                tmpl_ver = _get_meta_version(name, tmpl[name]["mappings"])
             except KeyError:
                 original_no_version = True
             else:
@@ -179,6 +283,11 @@ def put_template(es, name=None, mapping_name=None, body=None):
                 # All other error codes are some kind of error we don't attempt
                 # to retry.
                 raise
+        except Exception as e:
+            logger.error(
+                f"Unexpected exception checking %s: %r", name, e
+            )
+            raise
         else:
             retry = False
     end = time.time()
@@ -204,6 +313,7 @@ def streaming_bulk(es, actions, errorsfp, logger):
         duplicate, and failed documents, along with number of times a bulk
         request was retried.
     """
+    _import_elasticsearch(es)
     return _internal_bulk(
         es, actions, errorsfp, helpers.streaming_bulk, logger
     )
@@ -235,6 +345,7 @@ def parallel_bulk(
         duplicate, and failed documents, along with number of times a bulk
         request was retried.
     """
+    _import_elasticsearch(es)
     return _internal_bulk(
         es, actions, errorsfp, helpers.parallel_bulk, logger,
         chunk_size=chunk_size, max_chunk_bytes=max_chunk_bytes,
@@ -276,7 +387,7 @@ def _internal_bulk(es, actions, errorsfp, bulk_method, logger, **kwargs):
 
     def actions_tracking_closure(cl_actions):
         for cl_action in cl_actions:
-            for field in ("_id", "_index", "_type"):
+            for field in ("_id", "_index"):
                 assert (
                     field in cl_action
                 ), f"Action missing '{field}' field: {cl_action!r}"
@@ -431,7 +542,8 @@ def _internal_bulk(es, actions, errorsfp, bulk_method, logger, **kwargs):
 
     if len(actions_deque) > 0:
         logger.error(
-            "We still have {:d} actions in the deque", len(actions_deque)
+            "We still have {:d} actions in the deque",
+            len(actions_deque)
         )
     if len(actions_retry_deque) > 0:
         logger.error(
@@ -440,5 +552,5 @@ def _internal_bulk(es, actions, errorsfp, bulk_method, logger, **kwargs):
         )
 
     return (
-        beg, end, successes, duplicates, failures, retries_tracker['retries']
+        beg, end, successes, duplicates, failures, retries_tracker["retries"]
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-elasticsearch1
+elasticsearch>=7.0.0,<8.0.0

--- a/tests/parallel_bulk_test.py
+++ b/tests/parallel_bulk_test.py
@@ -3,7 +3,7 @@ import json
 import time
 import logging
 from collections import Counter
-from elasticsearch1 import helpers
+from elasticsearch import helpers
 
 from pyesbulk import parallel_bulk
 from tests.put_template_test import MyTime

--- a/tests/put_template_test.py
+++ b/tests/put_template_test.py
@@ -1,6 +1,6 @@
 import time
 import pytest
-from elasticsearch1 import exceptions as es_excs
+from elasticsearch import exceptions as es_excs
 
 from pyesbulk import put_template
 
@@ -100,6 +100,24 @@ def test_put_template():
     mpt = MockTemplateApis()
     es = MockElasticsearch(mpt)
     mappings = {'prefix-mapname0': {'_meta': {'version': 0}}}
+    body = dict(one=1, two=2, mappings=mappings)
+    res = put_template(
+        es, name="mytemplate", mapping_name="prefix-mapname0", body=body
+    )
+    beg, end, retry_count, note = res
+    assert beg == 0
+    assert end == 1
+    assert retry_count == 0
+    assert note == "original-no-version"
+    assert mpt.name == "mytemplate"
+    assert mpt.body == body
+
+
+def test_put_template_noname():
+    # Assert that there's nothing requiring a doc type
+    mpt = MockTemplateApis()
+    es = MockElasticsearch(mpt)
+    mappings = {'_meta': {'version': 0}}
     body = dict(one=1, two=2, mappings=mappings)
     res = put_template(
         es, name="mytemplate", mapping_name="prefix-mapname0", body=body

--- a/tests/streaming_bulk_test.py
+++ b/tests/streaming_bulk_test.py
@@ -3,7 +3,7 @@ import json
 import time
 import logging
 from collections import Counter
-from elasticsearch1 import helpers
+from elasticsearch import helpers
 
 from pyesbulk import streaming_bulk
 from tests.put_template_test import MyTime


### PR DESCRIPTION
This commit makes changes to the `pyesbulk` module to enable Pbench to upgrade from Elasticsearch V1 and the Python `elasticsearch1` module to Elasticsearch V7 and `elasticsearch`.

These changes are compatible with `elasticsearch1` and the current Pbench indexer using Elasticsearch V1.

Changes include:

- Removing dependencies on the nesting depth of the `"_meta": {"version": v}` stanza to support both V1 named templates and V7 recommended (V8 required) "anonymous" templates.
- Removing the static dependency on a particular Python Elasticsearch module by dynamically determining the module used to provide the supplied `Elasticsearch` object. Dynamically loading and binding the names is critical in order to get `except` clauses to match against the classes from the appropriate module.
- A non-existing template is reported by `get_template` now using a `NotFoundError` rather than a `TransportError` with a 404 `status_code`: the new code handles either way.
- The `_type` field in an Elasticsearch bulk index action is no longer required: this was deprecated in V7 and will be disallowed in V8.